### PR TITLE
Add llvm-config for linux targets in sample config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ target = ["aarch64-apple-darwin", "aarch64-unknown-freebsd-purecap"]
 [target.aarch64-apple-darwin]
 llvm-config = "/path/to/cheribuild-output-and-source/output/morello-sdk/bin/llvm-config"
 
+[target.x86_64-unknown-linux-gnu]
+llvm-config = "/path/to/cheribuild-output-and-source/output/morello-sdk/bin/llvm-config"
+
 # This section tells the compiler to use custom scripts for linking Hybrid programs.
 [target.aarch64-unknown-freebsd]
 cc = "/path/to/rust/clang-freebsd.sh"


### PR DESCRIPTION
Related to issue #3: I read the readme to quickly and though the llvm-config line in the config.toml was only for mac users (despite being written just one line above to change the target). 

In this modified readme, both targets are available.